### PR TITLE
Replace 'qbirc' with 'slate-irc'

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const tls = require('tls');
-const qb = require('qbirc');
+const qb = require('slate-irc');
 const Module = require('./irc-module.js');
 const EventEmitter = require('events');
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "dependencies": {
     "bluebird": "^3.2.1",
-    "qbirc": "^0.9.0"
+    "slate-irc": "^0.9.0"
   }
 }


### PR DESCRIPTION
The [qbirc](https://github.com/openirc/qbirc) project has been deprecated and replaced by [slate-irc](https://github.com/slate/slate-irc).